### PR TITLE
BUG: fixed numpy trig calls

### DIFF
--- a/pyValEIA/utils/filters.py
+++ b/pyValEIA/utils/filters.py
@@ -72,10 +72,10 @@ def simple_barrel_roll(xvar, yvar, barrel_radius, envelope=True,
             del_y = y_roi[i] - strt_con_y
 
             # Calculate the rolling angles
-            theta = np.atan(del_y / del_x)
+            theta = np.arctan(del_y / del_x)
             if 2 * barrel_radius >= np.sqrt((del_x) ** 2 + (del_y) ** 2):
-                beta = np.asin(np.sqrt((del_x) ** 2 + (del_y) ** 2)
-                               / (2 * barrel_radius))
+                beta = np.arcsin(np.sqrt((del_x) ** 2 + (del_y) ** 2)
+                                 / (2 * barrel_radius))
             else:
                 beta = np.pi / 2.0
             delta = beta - theta


### PR DESCRIPTION

# Description

Changed `atan` and `asin` to `arctan` and `arcsin`. Fixes #19.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Copy and pasted text from the file.

```
import numpy as np

# Set fake values for necessary variables
del_y = 0.5
del_x = 0.25
barrel_radius = 1.0

# Copy and paste altered lines
np.arctan(del_y / del_x)
np.arcsin(np.sqrt((del_x) ** 2 + (del_y) ** 2) / (2 * barrel_radius))
```

Yeilds:
```
np.float64(1.1071487177940906)
np.float64(0.28328216531053907)
```

## Test Configuration

- Operating system: OS X Sequoia
- Version number: Python 3.10
- Any details about your local setup that are relevant: N/A

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.md``, summarising the changes
- [x] Add yourself to ``.zenodo.json``
