### PR TITLE
BUG FIX: Density Scaling causing Saddle Bug

### DIFF
--- a/pyValEIA/eia/types.py
+++ b/pyValEIA/eia/types.py
@@ -140,7 +140,7 @@ def eia_slope_state(z_lat, lat, dens, ghost=True, zero_slope=0.5):
     lat_span = (max(sort_lat) - min(sort_lat))
 
     # Scale the density
-    sort_dens /= max(sort_dens) * lat_span
+    sort_dens = sort_dens / max(sort_dens) * lat_span
 
     # Save original zero-latitude locations
     z_lat_og = np.asarray(z_lat)


### PR DESCRIPTION
Updated eia.types.eia_slope_state so that the scaling is correct. This fixes the error causing every EIA type to be saddle_eia. The scaling resulted in all maxima being secondary and not primary maxima, which results in more Saddle designations.

# Description

The density scaling in pyValEIA.eia.types.eia_slope_state caused most EIA types to be saddle_eia.

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

To reproduce, run eia_slope_state or eia_complete function on TEC or Np.


```
from pyValEIA.eia.detection import eia_complete
(sort_lat, den_filt2, eia_state,
         z_lat, plats, p3lats) = eia_complete(
             mlat, density, "Ne")
```

## Test Configuration

- Operating system: macOS 14.4. 
- Version number: Python 3.11.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My commits are formatted appropriately (following the SciPy/NumPy style) 
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``Changelog.md``, summarising the changes
- [ ] Add yourself to ``CITATION.cff``
